### PR TITLE
Refactor the Nav title, context menu, and appnav

### DIFF
--- a/src/components/app-nav.tsx
+++ b/src/components/app-nav.tsx
@@ -25,11 +25,9 @@ function Nav({
 	pathname: string
 	matches: ReturnType<typeof useMatches>
 }) {
-	const match = matches.findLast(
-		(m) => !!m.loaderData && 'appnav' in m.loaderData
-	)
+	const match = matches.findLast((m) => !!m?.loaderData?.appnav)
 	console.log(`This is the match`, match)
-	const links = useLinks(match.loaderData.appnav)
+	const links = useLinks(match?.loaderData.appnav)
 	if (!links || !links.length) return null
 	return (
 		<NavigationMenu className="mb-4">

--- a/src/components/app-nav.tsx
+++ b/src/components/app-nav.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router'
+import { Link, useMatches } from '@tanstack/react-router'
 import {
 	NavigationMenu,
 	NavigationMenuItem,
@@ -8,9 +8,29 @@ import {
 import { LinkType } from '@/types/main'
 import { useLocation } from '@tanstack/react-router'
 import { cn } from '@/lib/utils'
+import { useLinks } from '@/hooks/links'
 
-export function AppNav({ links }: { links: Array<LinkType> }) {
+export function AppNav() {
 	const { pathname } = useLocation()
+	const matches = useMatches()
+	if (!pathname || matches.some((match) => match.status === 'pending'))
+		return null
+	return <Nav pathname={pathname} matches={matches} />
+}
+
+function Nav({
+	pathname,
+	matches,
+}: {
+	pathname: string
+	matches: ReturnType<typeof useMatches>
+}) {
+	const match = matches.findLast(
+		(m) => !!m.loaderData && 'appnav' in m.loaderData
+	)
+	console.log(`This is the match`, match)
+	const links = useLinks(match.loaderData.appnav)
+	if (!links || !links.length) return null
 	return (
 		<NavigationMenu className="mb-4">
 			<NavigationMenuList className="w-full flex flex-row">

--- a/src/components/app-nav.tsx
+++ b/src/components/app-nav.tsx
@@ -6,29 +6,17 @@ import {
 	NavigationMenuList,
 } from './ui/navigation-menu'
 import { LinkType } from '@/types/main'
-import { useLocation } from '@tanstack/react-router'
-import { cn } from '@/lib/utils'
 import { useLinks } from '@/hooks/links'
 import { ScrollArea, ScrollBar } from './ui/scroll-area'
 
 export function AppNav() {
-	const { pathname } = useLocation()
 	const matches = useMatches()
-	if (!pathname || matches.some((match) => match.status === 'pending'))
-		return null
-	return <Nav pathname={pathname} matches={matches} />
+	if (matches.some((match) => match.status === 'pending')) return null
+	return <Nav matches={matches} />
 }
 
-function Nav({
-	pathname,
-	matches,
-}: {
-	pathname: string
-	matches: ReturnType<typeof useMatches>
-}) {
-	const exactMatch = matches.at(-1)
+function Nav({ matches }: { matches: ReturnType<typeof useMatches> }) {
 	const match = matches.findLast((m) => !!m?.loaderData?.appnav)
-	console.log(`This is the match`, match)
 	const links = useLinks(match?.loaderData.appnav)
 	if (!links || !links.length) return null
 	return (
@@ -43,12 +31,10 @@ function Nav({
 							<NavigationMenuLink asChild>
 								<Link
 									{...l.link}
-									className={cn(
-										'border-b-2 flex flex-row gap-2 items-center justify-center py-2',
-										pathname === l.link.to ?
-											'border-primary'
-										:	'border-transparent'
-									)}
+									className="border-b-2 flex flex-row gap-2 items-center justify-center py-2"
+									activeProps={{ className: 'border-primary' }}
+									activeOptions={{ exact: true }}
+									inactiveProps={{ className: 'border-transparent' }}
 								>
 									<l.Icon className="size-4" /> {l.name}
 								</Link>

--- a/src/components/app-nav.tsx
+++ b/src/components/app-nav.tsx
@@ -9,6 +9,7 @@ import { LinkType } from '@/types/main'
 import { useLocation } from '@tanstack/react-router'
 import { cn } from '@/lib/utils'
 import { useLinks } from '@/hooks/links'
+import { ScrollArea, ScrollBar } from './ui/scroll-area'
 
 export function AppNav() {
 	const { pathname } = useLocation()
@@ -25,34 +26,38 @@ function Nav({
 	pathname: string
 	matches: ReturnType<typeof useMatches>
 }) {
+	const exactMatch = matches.at(-1)
 	const match = matches.findLast((m) => !!m?.loaderData?.appnav)
 	console.log(`This is the match`, match)
 	const links = useLinks(match?.loaderData.appnav)
 	if (!links || !links.length) return null
 	return (
-		<NavigationMenu className="mb-4">
-			<NavigationMenuList className="w-full flex flex-row">
-				{links.map((l: LinkType) => (
-					<NavigationMenuItem
-						className="px-4 rounded hover:bg-primary/20"
-						key={l.link.to}
-					>
-						<NavigationMenuLink asChild>
-							<Link
-								{...l.link}
-								className={cn(
-									'border-b-2 flex flex-row gap-2 items-center justify-center py-2',
-									pathname === l.link.to ?
-										'border-primary'
-									:	'border-transparent'
-								)}
-							>
-								<l.Icon className="size-4" /> {l.name}
-							</Link>
-						</NavigationMenuLink>
-					</NavigationMenuItem>
-				))}
-			</NavigationMenuList>
-		</NavigationMenu>
+		<ScrollArea>
+			<NavigationMenu className="mb-4">
+				<NavigationMenuList className="w-full flex flex-row">
+					{links.map((l: LinkType) => (
+						<NavigationMenuItem
+							className="px-4 rounded hover:bg-primary/20"
+							key={l.link.to}
+						>
+							<NavigationMenuLink asChild>
+								<Link
+									{...l.link}
+									className={cn(
+										'border-b-2 flex flex-row gap-2 items-center justify-center py-2',
+										pathname === l.link.to ?
+											'border-primary'
+										:	'border-transparent'
+									)}
+								>
+									<l.Icon className="size-4" /> {l.name}
+								</Link>
+							</NavigationMenuLink>
+						</NavigationMenuItem>
+					))}
+				</NavigationMenuList>
+			</NavigationMenu>
+			<ScrollBar orientation="horizontal" />
+		</ScrollArea>
 	)
 }

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -10,75 +10,90 @@ import {
 import { Link, useMatches, useNavigate } from '@tanstack/react-router'
 import { SidebarTrigger } from '@/components/ui/sidebar'
 import { Separator } from '@/components/ui/separator'
+import { useLinks } from '@/hooks/links'
 
 export default function Navbar() {
-	const [isOpen, setIsOpen] = useState(false)
 	const matches = useMatches()
-	const navigate = useNavigate()
-	const goBack = useCallback(() => {
-		void navigate({ to: '..' })
-	}, [navigate])
-
 	if (matches.some((match) => match.status === 'pending')) return null
-	const matchesArray = matches.filter((m) => m?.loaderData !== undefined)
-	// console.log(`matches`, matchesArray, matches)
-	const lastMatch = matchesArray.at(-1)
-	const data =
-		lastMatch && 'navbar' in lastMatch.loaderData ?
-			lastMatch.loaderData.navbar
-		:	null
-	if (!data) return null
-
-	const Icon = !data ? null : data.Icon
-	const onBackClick = data?.onBackClick ?? goBack
 
 	return (
 		<nav className="flex items-center justify-between py-3 px-[1cqw] mb-4 border-b">
 			<div className="flex items-center gap-[1cqw] h-12">
 				<SidebarTrigger />
-				<Button variant="ghost" size="icon-sm" onClick={onBackClick}>
-					<ChevronLeft />
-					<span className="sr-only">Back</span>
-				</Button>
-				<Separator orientation="vertical" className="mx-2 h-6" />
-				<div className="flex flex-row items-center gap-[1cqw]">
-					{Icon ?
-						<span className="rounded">
-							<Icon size="24" />
-						</span>
-					:	<>&nbsp;</>}
-					<div>
-						<h1 className="text-lg font-bold">{data?.title}</h1>
-						<p className="text-sm">{data?.subtitle}</p>
-					</div>
-				</div>
+				<Title matches={matches} />
 			</div>
 
-			{!(data?.contextMenu?.length > 0) ? null : (
-				<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-					<DropdownMenuTrigger asChild>
-						<Button variant="ghost" size="icon">
-							<MoreVertical />
-							<span className="sr-only">Open menu</span>
-						</Button>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end" className="w-56">
-						{data?.contextMenu.map(({ link, name, Icon }, index) => (
-							<DropdownMenuItem key={index}>
-								<Link
-									{...link}
-									className="w-full flex flex-row gap-2 justify-content-center"
-								>
-									<Icon className="size-[1.25rem]" />
-									{name}
-								</Link>
-							</DropdownMenuItem>
-						)) || (
-							<DropdownMenuItem disabled>No options available</DropdownMenuItem>
-						)}
-					</DropdownMenuContent>
-				</DropdownMenu>
-			)}
+			<ContextMenu matches={matches} />
 		</nav>
+	)
+}
+
+function Title({
+	matches,
+}: {
+	matches: Array<{ loaderData?: { titleBar?: any } }>
+}) {
+	const navigate = useNavigate()
+	const goBack = useCallback(() => {
+		void navigate({ to: '..' })
+	}, [navigate])
+
+	const match = matches.findLast((m) => !!m?.loaderData?.titleBar)
+	const data = match?.loaderData.titleBar
+	if (!data) return null
+	const Icon = !data ? null : data.Icon
+	const onBackClick = data?.onBackClick ?? goBack
+	return (
+		<>
+			<Button variant="ghost" size="icon-sm" onClick={onBackClick}>
+				<ChevronLeft />
+				<span className="sr-only">Back</span>
+			</Button>
+			<Separator orientation="vertical" className="mx-2 h-6" />
+			<div className="flex flex-row items-center gap-[1cqw]">
+				{Icon ?
+					<span className="rounded">
+						<Icon size="24" />
+					</span>
+				:	<>&nbsp;</>}
+				<div>
+					<h1 className="text-lg font-bold">{data?.title}</h1>
+					<p className="text-sm">{data?.subtitle}</p>
+				</div>
+			</div>
+		</>
+	)
+}
+
+function ContextMenu({ matches }) {
+	const [isOpen, setIsOpen] = useState(false)
+	const match = matches.findLast((m) => !!m?.loaderData?.contextMenu)
+	const links = useLinks(match?.loaderData.contextMenu)
+	if (!links || !links.length) return null
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild>
+				<Button variant="ghost" size="icon">
+					<MoreVertical />
+					<span className="sr-only">Open menu</span>
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="w-56">
+				{links.map(({ link, name, Icon }, index) => (
+					<DropdownMenuItem key={index}>
+						<Link
+							{...link}
+							className="w-full flex flex-row gap-2 justify-content-center"
+						>
+							<Icon className="size-[1.25rem]" />
+							{name}
+						</Link>
+					</DropdownMenuItem>
+				)) || (
+					<DropdownMenuItem disabled>No options available</DropdownMenuItem>
+				)}
+			</DropdownMenuContent>
+		</DropdownMenu>
 	)
 }

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -19,6 +19,7 @@ export default function Navbar() {
 		void navigate({ to: '..' })
 	}, [navigate])
 
+	if (matches.some((match) => match.status === 'pending')) return null
 	const matchesArray = matches.filter((m) => m?.loaderData !== undefined)
 	// console.log(`matches`, matchesArray, matches)
 	const lastMatch = matchesArray.at(-1)

--- a/src/hooks/links.ts
+++ b/src/hooks/links.ts
@@ -130,10 +130,11 @@ const links = (lang?: string): Record<string, LinkType> => ({
 
 export function useLinks(paths: Array<string>) {
 	const { lang } = useParams({ strict: false })
-	return useMemo(() => makeLinks(paths, lang), [lang])
+	return useMemo(() => makeLinks(paths, lang), [lang, paths])
 }
 
 export function makeLinks(paths: Array<string>, lang?: string) {
+	if (!paths) return null
 	const l = links(lang)
 	return paths.map((p) => l[p])
 }

--- a/src/routes/_user.tsx
+++ b/src/routes/_user.tsx
@@ -1,5 +1,6 @@
 import { AppSidebarLayout } from '@/components/app-sidebar-layout'
 import Navbar from '@/components/navbar'
+import { AppNav } from '@/components/app-nav'
 import { profileQuery } from '@/lib/use-profile'
 import { NavbarData } from '@/types/main'
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router'
@@ -41,6 +42,7 @@ function UserLayout() {
 	return (
 		<AppSidebarLayout>
 			<Navbar />
+			<AppNav />
 			<Outlet />
 		</AppSidebarLayout>
 	)

--- a/src/routes/_user.tsx
+++ b/src/routes/_user.tsx
@@ -2,7 +2,7 @@ import { AppSidebarLayout } from '@/components/app-sidebar-layout'
 import Navbar from '@/components/navbar'
 import { AppNav } from '@/components/app-nav'
 import { profileQuery } from '@/lib/use-profile'
-import { NavbarData } from '@/types/main'
+import { TitleBar } from '@/types/main'
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router'
 import { Home } from 'lucide-react'
 
@@ -32,7 +32,7 @@ export const Route = createFileRoute('/_user')({
 				title: `Learning Home`,
 				subtitle: `Which deck are we studying today?`,
 				Icon: Home,
-			} as NavbarData,
+			} as TitleBar,
 		}
 	},
 	component: UserLayout,

--- a/src/routes/_user.tsx
+++ b/src/routes/_user.tsx
@@ -28,7 +28,7 @@ export const Route = createFileRoute('/_user')({
 			// this line is making sure the entire route tree awaits till we have the profile
 			await queryClient.ensureQueryData(profileQuery(auth.userId))
 		return {
-			navbar: {
+			titleBar: {
 				title: `Learning Home`,
 				subtitle: `Which deck are we studying today?`,
 				Icon: Home,

--- a/src/routes/_user/friends.tsx
+++ b/src/routes/_user/friends.tsx
@@ -2,8 +2,6 @@ import { NavbarData } from '@/types/main'
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { relationsQuery } from '@/lib/friends'
 import { HeartHandshake } from 'lucide-react'
-import { useLinks } from '@/hooks/links'
-import { AppNav } from '@/components/app-nav'
 
 export const Route = createFileRoute('/_user/friends')({
 	component: FriendsPage,
@@ -15,16 +13,11 @@ export const Route = createFileRoute('/_user/friends')({
 				title: `Manage Friends and Contacts`,
 				Icon: HeartHandshake,
 			} as NavbarData,
+			appnav: ['/friends', '/friends/invite', '/friends/search'],
 		}
 	},
 })
 
 function FriendsPage() {
-	const navlinks = useLinks(['/friends', '/friends/invite', '/friends/search'])
-	return (
-		<>
-			<AppNav links={navlinks} />
-			<Outlet />
-		</>
-	)
+	return <Outlet />
 }

--- a/src/routes/_user/friends.tsx
+++ b/src/routes/_user/friends.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute('/_user/friends')({
 		const { queryClient, userId } = context
 		await queryClient.ensureQueryData(relationsQuery(userId))
 		return {
-			navbar: {
+			titleBar: {
 				title: `Manage Friends and Contacts`,
 				Icon: HeartHandshake,
 			} as NavbarData,

--- a/src/routes/_user/friends.tsx
+++ b/src/routes/_user/friends.tsx
@@ -1,4 +1,4 @@
-import { NavbarData } from '@/types/main'
+import { TitleBar } from '@/types/main'
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { relationsQuery } from '@/lib/friends'
 import { HeartHandshake } from 'lucide-react'
@@ -12,7 +12,7 @@ export const Route = createFileRoute('/_user/friends')({
 			titleBar: {
 				title: `Manage Friends and Contacts`,
 				Icon: HeartHandshake,
-			} as NavbarData,
+			} as TitleBar,
 			appnav: ['/friends', '/friends/invite', '/friends/search'],
 		}
 	},

--- a/src/routes/_user/learn.$lang.review.tsx
+++ b/src/routes/_user/learn.$lang.review.tsx
@@ -30,6 +30,7 @@ export const Route = createFileRoute('/_user/learn/$lang/review')({
 			reviewableCards: data.reviewables.map(
 				(r) => data.deck.cardsMap[r.phrase_id]
 			),
+			appnav: [],
 			navbar: {
 				title: `Review ${languages[lang]} cards`,
 				Icon: BookHeart,

--- a/src/routes/_user/learn.$lang.review.tsx
+++ b/src/routes/_user/learn.$lang.review.tsx
@@ -6,7 +6,7 @@ import { FlashCardReviewSession } from '@/components/flash-card-review-session'
 import languages from '@/lib/languages'
 import { deckQueryOptions } from '@/lib/use-deck'
 import { reviewablesQueryOptions } from '@/lib/use-reviewables'
-import { BookHeart, Search, Settings, SquarePlus } from 'lucide-react'
+import { BookHeart } from 'lucide-react'
 
 export const Route = createFileRoute('/_user/learn/$lang/review')({
 	component: ReviewPage,

--- a/src/routes/_user/learn.$lang.review.tsx
+++ b/src/routes/_user/learn.$lang.review.tsx
@@ -31,35 +31,14 @@ export const Route = createFileRoute('/_user/learn/$lang/review')({
 				(r) => data.deck.cardsMap[r.phrase_id]
 			),
 			appnav: [],
-			navbar: {
+			contextMenu: [
+				'/learn/$lang/search',
+				'/learn/$lang/add-phrase',
+				'/learn/$lang/deck-settings',
+			],
+			titleBar: {
 				title: `Review ${languages[lang]} cards`,
 				Icon: BookHeart,
-				contextMenu: [
-					{
-						name: `Search ${languages[lang]}`,
-						link: {
-							to: '/learn/$lang/search',
-							params: { lang },
-						},
-						Icon: Search,
-					},
-					{
-						name: 'Add a phrase',
-						link: {
-							to: '/learn/$lang/add-phrase',
-							params: { lang },
-						},
-						Icon: SquarePlus,
-					},
-					{
-						name: 'Deck settings',
-						link: {
-							to: '/learn/$lang/deck-settings',
-							params: { lang },
-						},
-						Icon: Settings,
-					},
-				],
 			} as NavbarData,
 		}
 	},

--- a/src/routes/_user/learn.$lang.review.tsx
+++ b/src/routes/_user/learn.$lang.review.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
-import { NavbarData } from '@/types/main'
+import { TitleBar } from '@/types/main'
 import { FlashCardReviewSession } from '@/components/flash-card-review-session'
 import languages from '@/lib/languages'
 import { deckQueryOptions } from '@/lib/use-deck'
@@ -39,7 +39,7 @@ export const Route = createFileRoute('/_user/learn/$lang/review')({
 			titleBar: {
 				title: `Review ${languages[lang]} cards`,
 				Icon: BookHeart,
-			} as NavbarData,
+			} as TitleBar,
 		}
 	},
 })

--- a/src/routes/_user/learn.$lang.tsx
+++ b/src/routes/_user/learn.$lang.tsx
@@ -36,53 +36,15 @@ export const Route = createFileRoute('/_user/learn/$lang')({
 				'/learn/$lang/library',
 				'/learn/$lang/search',
 				'/learn/$lang/add-phrase',
+			],
+			contextMenu: [
+				'/learn/$lang/search',
+				'/learn/$lang/add-phrase',
 				'/learn/$lang/deck-settings',
 			],
-			navbar: {
+			titleBar: {
 				title: `${languages[lang]} Deck`,
 				Icon: BookHeart,
-				contextMenu: [
-					{
-						name: 'Quick search',
-						link: {
-							to: '/learn/$lang/search',
-							params: { lang },
-						},
-						Icon: Search,
-					},
-					{
-						name: 'Start a review',
-						link: {
-							to: '/learn/$lang/review',
-							params: { lang },
-						},
-						Icon: Rocket,
-					},
-					{
-						name: `Browse ${languages[lang]} library`,
-						link: {
-							to: '/learn/$lang/library',
-							params: { lang },
-						},
-						Icon: BookCopy,
-					},
-					{
-						name: 'Add a phrase',
-						link: {
-							to: '/learn/$lang/add-phrase',
-							params: { lang },
-						},
-						Icon: NotebookPen,
-					},
-					{
-						name: 'Deck settings',
-						link: {
-							to: '/learn/$lang/deck-settings',
-							params: { lang },
-						},
-						Icon: Settings,
-					},
-				],
 			} as NavbarData,
 		}
 	},

--- a/src/routes/_user/learn.$lang.tsx
+++ b/src/routes/_user/learn.$lang.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router'
-import { NavbarData } from '@/types/main'
+import { TitleBar } from '@/types/main'
 import languages from '@/lib/languages'
 import { languageQueryOptions } from '@/lib/use-language'
 import { deckQueryOptions } from '@/lib/use-deck'
@@ -45,7 +45,7 @@ export const Route = createFileRoute('/_user/learn/$lang')({
 			titleBar: {
 				title: `${languages[lang]} Deck`,
 				Icon: BookHeart,
-			} as NavbarData,
+			} as TitleBar,
 		}
 	},
 })

--- a/src/routes/_user/learn.$lang.tsx
+++ b/src/routes/_user/learn.$lang.tsx
@@ -6,14 +6,11 @@ import { deckQueryOptions } from '@/lib/use-deck'
 import {
 	BookCopy,
 	BookHeart,
-	Contact,
 	NotebookPen,
 	Rocket,
 	Search,
 	Settings,
 } from 'lucide-react'
-import { AppNav } from '@/components/app-nav'
-import { useLinks } from '@/hooks/links'
 
 export const Route = createFileRoute('/_user/learn/$lang')({
 	component: LanguageLayout,
@@ -33,6 +30,14 @@ export const Route = createFileRoute('/_user/learn/$lang')({
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		const both = { l: await languageLoader, d: await deckLoader }
 		return {
+			appnav: [
+				'/learn/$lang',
+				'/learn/$lang/review',
+				'/learn/$lang/library',
+				'/learn/$lang/search',
+				'/learn/$lang/add-phrase',
+				'/learn/$lang/deck-settings',
+			],
 			navbar: {
 				title: `${languages[lang]} Deck`,
 				Icon: BookHeart,
@@ -77,13 +82,6 @@ export const Route = createFileRoute('/_user/learn/$lang')({
 						},
 						Icon: Settings,
 					},
-					{
-						name: 'Friends and contacts',
-						link: {
-							to: '/friends',
-						},
-						Icon: Contact,
-					},
 				],
 			} as NavbarData,
 		}
@@ -91,18 +89,5 @@ export const Route = createFileRoute('/_user/learn/$lang')({
 })
 
 function LanguageLayout() {
-	const navlinks = useLinks([
-		'/learn/$lang/review',
-		'/learn/$lang',
-		'/learn/$lang/library',
-		'/learn/$lang/search',
-		'/learn/$lang/add-phrase',
-	])
-	console.log(navlinks)
-	return (
-		<>
-			<AppNav links={navlinks} />
-			<Outlet />
-		</>
-	)
+	return <Outlet />
 }

--- a/src/routes/_user/learn.add-deck.tsx
+++ b/src/routes/_user/learn.add-deck.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button'
 import { buttonVariants } from '@/components/ui/button-variants'
 import { useNewDeckMutation } from '@/lib/mutate-deck'
 import { useProfile } from '@/lib/use-profile'
-import { NavbarData } from '@/types/main'
+import { TitleBar } from '@/types/main'
 import { Badge } from '@/components/ui/badge'
 import languages from '@/lib/languages'
 import Callout from '@/components/ui/callout'
@@ -20,7 +20,7 @@ export const Route = createFileRoute('/_user/learn/add-deck')({
 		titleBar: {
 			title: `Start Learning a New Language`,
 			Icon: RouteIcon,
-		} as NavbarData,
+		} as TitleBar,
 	}),
 	component: NewDeckForm,
 })

--- a/src/routes/_user/learn.add-deck.tsx
+++ b/src/routes/_user/learn.add-deck.tsx
@@ -17,7 +17,7 @@ import { RouteIcon } from 'lucide-react'
 
 export const Route = createFileRoute('/_user/learn/add-deck')({
 	loader: () => ({
-		navbar: {
+		titleBar: {
 			title: `Start Learning a New Language`,
 			Icon: RouteIcon,
 		} as NavbarData,

--- a/src/routes/_user/learn.index.tsx
+++ b/src/routes/_user/learn.index.tsx
@@ -3,7 +3,7 @@ import { FolderPlus, Home, Search, Star, Users } from 'lucide-react'
 import { Loader } from '@/components/ui/loader'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
-import type { NavbarData } from '@/types/main'
+import type { TitleBar } from '@/types/main'
 import { useProfile } from '@/lib/use-profile'
 import { ago } from '@/lib/dayjs'
 
@@ -16,7 +16,7 @@ export const Route = createFileRoute('/_user/learn/')({
 				title: `Learning Home`,
 				subtitle: `Which deck are we studying today?`,
 				Icon: Home,
-			} as NavbarData,
+			} as TitleBar,
 		}
 	},
 	component: Page,

--- a/src/routes/_user/learn.index.tsx
+++ b/src/routes/_user/learn.index.tsx
@@ -11,26 +11,11 @@ export const Route = createFileRoute('/_user/learn/')({
 	loader: () => {
 		return {
 			appnav: ['/learn', '/learn/add-deck', '/learn/quick-search'],
-			navbar: {
+			contextMenu: ['/learn/add-deck', '/learn/quick-search'],
+			titleBar: {
 				title: `Learning Home`,
 				subtitle: `Which deck are we studying today?`,
 				Icon: Home,
-				contextMenu: [
-					{
-						name: 'New Deck',
-						link: {
-							to: '/learn/add-deck',
-						},
-						Icon: FolderPlus,
-					},
-					{
-						name: 'Quick search',
-						link: {
-							to: '/learn/quick-search',
-						},
-						Icon: Search,
-					},
-				],
 			} as NavbarData,
 		}
 	},

--- a/src/routes/_user/learn.index.tsx
+++ b/src/routes/_user/learn.index.tsx
@@ -8,17 +8,6 @@ import { useProfile } from '@/lib/use-profile'
 import { ago } from '@/lib/dayjs'
 
 export const Route = createFileRoute('/_user/learn/')({
-	loader: () => {
-		return {
-			appnav: ['/learn', '/learn/add-deck', '/learn/quick-search'],
-			contextMenu: ['/learn/add-deck', '/learn/quick-search'],
-			titleBar: {
-				title: `Learning Home`,
-				subtitle: `Which deck are we studying today?`,
-				Icon: Home,
-			} as TitleBar,
-		}
-	},
 	component: Page,
 })
 

--- a/src/routes/_user/learn.index.tsx
+++ b/src/routes/_user/learn.index.tsx
@@ -6,12 +6,11 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import type { NavbarData } from '@/types/main'
 import { useProfile } from '@/lib/use-profile'
 import { ago } from '@/lib/dayjs'
-import { AppNav } from '@/components/app-nav'
-import { useLinks } from '@/hooks/links'
 
 export const Route = createFileRoute('/_user/learn/')({
 	loader: () => {
 		return {
+			appnav: ['/learn', '/learn/add-deck', '/learn/quick-search'],
 			navbar: {
 				title: `Learning Home`,
 				subtitle: `Which deck are we studying today?`,
@@ -40,62 +39,54 @@ export const Route = createFileRoute('/_user/learn/')({
 
 export default function Page() {
 	const { data: profile, isPending } = useProfile()
-	const navlinks = useLinks([
-		'/learn',
-		'/learn/add-deck',
-		'/learn/quick-search',
-	])
 	return (
-		<>
-			<AppNav links={navlinks} />
-			<main className="grid gap-4 @lg:grid-cols-2">
-				{isPending ?
-					<Loader />
-				:	Object.entries(profile?.decksMap).map(([key, deck]) => (
-						<Link
-							key={key}
-							to="/learn/$lang"
-							params={{ lang: key }}
-							className="block transition-transform rounded-lg focus:outline-blue-500 focus:ring-blue-500 focus:ring-offset-1"
+		<main className="grid gap-4 @lg:grid-cols-2">
+			{isPending ?
+				<Loader />
+			:	Object.entries(profile?.decksMap).map(([key, deck]) => (
+					<Link
+						key={key}
+						to="/learn/$lang"
+						params={{ lang: key }}
+						className="block transition-transform rounded-lg focus:outline-blue-500 focus:ring-blue-500 focus:ring-offset-1"
+					>
+						<Card
+							key={deck.language}
+							className="overflow-hidden h-full hover:border-primary"
 						>
-							<Card
-								key={deck.language}
-								className="overflow-hidden h-full hover:border-primary"
-							>
-								<CardHeader className="bg-primary text-white dark">
-									<CardTitle>
-										{deck.language}{' '}
-										<span className="text-xs text-muted-foreground">{key}</span>
-									</CardTitle>
-								</CardHeader>
-								<CardContent className="p-4 space-y-2">
-									<div>
-										<p className="text-sm text-muted-foreground">
-											{deck.cards_active} active cards
-										</p>
-										<p className="text-sm text-muted-foreground">
-											Last studied:{' '}
-											{deck.most_recent_review_at ?
-												ago(deck.most_recent_review_at)
-											:	'never'}
-										</p>
+							<CardHeader className="bg-primary text-white dark">
+								<CardTitle>
+									{deck.language}{' '}
+									<span className="text-xs text-muted-foreground">{key}</span>
+								</CardTitle>
+							</CardHeader>
+							<CardContent className="p-4 space-y-2">
+								<div>
+									<p className="text-sm text-muted-foreground">
+										{deck.cards_active} active cards
+									</p>
+									<p className="text-sm text-muted-foreground">
+										Last studied:{' '}
+										{deck.most_recent_review_at ?
+											ago(deck.most_recent_review_at)
+										:	'never'}
+									</p>
+								</div>
+								<div className="flex items-center justify-between">
+									<div className="flex items-center space-x-1">
+										<Users className="h-4 w-4 text-info" />
+										<span className="text-sm">{0} friends studying</span>
 									</div>
-									<div className="flex items-center justify-between">
-										<div className="flex items-center space-x-1">
-											<Users className="h-4 w-4 text-info" />
-											<span className="text-sm">{0} friends studying</span>
-										</div>
-										<div className="flex items-center space-x-1">
-											<Star className="h-4 w-4 text-warning" />
-											<span className="text-sm">{4.5}</span>
-										</div>
+									<div className="flex items-center space-x-1">
+										<Star className="h-4 w-4 text-warning" />
+										<span className="text-sm">{4.5}</span>
 									</div>
-								</CardContent>
-							</Card>
-						</Link>
-					))
-				}
-			</main>
-		</>
+								</div>
+							</CardContent>
+						</Card>
+					</Link>
+				))
+			}
+		</main>
 	)
 }

--- a/src/routes/_user/learn.quick-search.tsx
+++ b/src/routes/_user/learn.quick-search.tsx
@@ -4,7 +4,7 @@ import { NavbarData } from '@/types/main'
 // @@BLANKROUTE maybe remove this route??
 export const Route = createFileRoute('/_user/learn/quick-search')({
 	loader: () => ({
-		navbar: {
+		titleBar: {
 			title: `Quick Search for a Phrase`,
 		} as NavbarData,
 	}),

--- a/src/routes/_user/learn.quick-search.tsx
+++ b/src/routes/_user/learn.quick-search.tsx
@@ -1,12 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { NavbarData } from '@/types/main'
+import { TitleBar } from '@/types/main'
 
 // @@BLANKROUTE maybe remove this route??
 export const Route = createFileRoute('/_user/learn/quick-search')({
 	loader: () => ({
 		titleBar: {
 			title: `Quick Search for a Phrase`,
-		} as NavbarData,
+		} as TitleBar,
 	}),
 	component: () => <div>Hello /_app/learn/quick-search!</div>,
 })

--- a/src/routes/_user/learn.tsx
+++ b/src/routes/_user/learn.tsx
@@ -7,6 +7,8 @@ export const Route = createFileRoute('/_user/learn')({
 	component: () => <LearnLayout />,
 	loader: () => {
 		return {
+			appnav: ['/learn', '/learn/add-deck', '/learn/quick-search'],
+			contextMenu: ['/learn/add-deck', '/learn/quick-search'],
 			titleBar: {
 				title: `Learning Home`,
 				subtitle: `Which deck are we studying today?`,

--- a/src/routes/_user/learn.tsx
+++ b/src/routes/_user/learn.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute('/_user/learn')({
 	component: () => <LearnLayout />,
 	loader: () => {
 		return {
-			navbar: {
+			titleBar: {
 				title: `Learning Home`,
 				subtitle: `Which deck are we studying today?`,
 				Icon: Home,

--- a/src/routes/_user/learn.tsx
+++ b/src/routes/_user/learn.tsx
@@ -1,4 +1,4 @@
-import { NavbarData } from '@/types/main'
+import { TitleBar } from '@/types/main'
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 
 import { Home } from 'lucide-react'
@@ -11,7 +11,7 @@ export const Route = createFileRoute('/_user/learn')({
 				title: `Learning Home`,
 				subtitle: `Which deck are we studying today?`,
 				Icon: Home,
-			} as NavbarData,
+			} as TitleBar,
 		}
 	},
 })

--- a/src/routes/_user/profile.tsx
+++ b/src/routes/_user/profile.tsx
@@ -5,7 +5,7 @@ import { UserPen } from 'lucide-react'
 export const Route = createFileRoute('/_user/profile')({
 	component: ProfilePage,
 	loader: () => ({
-		navbar: {
+		titleBar: {
 			title: `Manage your Profile`,
 			Icon: UserPen,
 		} as NavbarData,

--- a/src/routes/_user/profile.tsx
+++ b/src/routes/_user/profile.tsx
@@ -1,4 +1,4 @@
-import { NavbarData } from '@/types/main'
+import { TitleBar } from '@/types/main'
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { UserPen } from 'lucide-react'
 
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/_user/profile')({
 		titleBar: {
 			title: `Manage your Profile`,
 			Icon: UserPen,
-		} as NavbarData,
+		} as TitleBar,
 	}),
 })
 

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -31,12 +31,11 @@ export type MenuType = LinkType & {
 	items: Array<LinkType>
 }
 
-export type NavbarData = {
+export type TitleBar = {
 	title: string
 	subtitle?: string
 	Icon?: LucideIcon
 	onBackClick?: () => void
-	contextMenu?: Array<LinkType>
 }
 
 export type UseSBQuery<T> = UseQueryResult<T, PostgrestError>


### PR DESCRIPTION
This PR should refactor the navbar so that app nav, context menu, and title bar so that they are now three independent pieces of the LoaderData object and their respective components will always render the most recent match for which they are present. (So you can add a title without specifying context menu, and still inherit the most recent context menu, or any other combination of things.) 

We can also specify a blank or null appnav or contextmenu with `{ contextMenu: [] }` and the other parts will still show up, inheriting from the most recent match where they are present.

Hopefully this will mean less boilerplate for creating new screens, while still maintaining proper navigation options for the user.