### PR TITLE
Add phrase detail page, permalinks, share buttons

### DIFF
--- a/src/components/add-translations-dialog.tsx
+++ b/src/components/add-translations-dialog.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
-import { NotebookPen } from 'lucide-react'
+import { Plus } from 'lucide-react'
 
 import supabase from '@/lib/supabase-client'
 import {
@@ -81,7 +81,7 @@ export function AddTranslationsDialog({
 		<Dialog>
 			<DialogTrigger asChild ref={closeRef}>
 				<Button {...props}>
-					<NotebookPen /> Add another translation
+					<Plus /> Add translation
 				</Button>
 			</DialogTrigger>
 			<DialogContent className="w-[92%] max-w-[425px]">

--- a/src/components/copy-link-button.tsx
+++ b/src/components/copy-link-button.tsx
@@ -1,0 +1,45 @@
+import { Copy } from 'lucide-react'
+import { Button } from './ui/button'
+import toast from 'react-hot-toast'
+import { ButtonProps } from './ui/button-variants'
+
+export default function CopyLinkButton({
+	url,
+	text = 'Copy link',
+	variant = 'ghost',
+	size = 'badge',
+	className = '',
+	...props
+}: {
+	url?: string
+	text?: string
+	variant?: string
+	size?: string
+	className?: string
+} & ButtonProps) {
+	const copyLink = () => {
+		// @TODO this is not working on my laptop (anymore) idk why
+		if (!navigator?.clipboard) toast.error('Failed to copy link')
+		else
+			navigator.clipboard
+				.writeText(url || window?.location?.href)
+				.then(() => {
+					toast.success('Link copied to clipboard')
+				})
+				.catch(() => {
+					toast.error('Failed to copy link')
+				})
+	}
+	return (
+		<Button
+			onClick={copyLink}
+			variant={variant}
+			size={size}
+			className={className}
+			{...props}
+		>
+			<Copy className="h-4 w-4" />
+			<span className="hidden @xl:block">{text}</span>
+		</Button>
+	)
+}

--- a/src/components/flagged.tsx
+++ b/src/components/flagged.tsx
@@ -1,11 +1,14 @@
 import { flags } from '@/lib/flags'
+import { cn } from '@/lib/utils'
 import { ReactNode } from '@tanstack/react-router'
 
 export default function Flagged({
 	name,
 	children,
+	className,
 }: {
 	name: keyof typeof flags
+	className?: string
 	children: ReactNode
 }) {
 	// the disabled flag is an override; hides the content even in dev mode
@@ -16,5 +19,7 @@ export default function Flagged({
 	// show content in dev/preview mode, with a little yellow border
 	return import.meta.env.PROD ?
 			null
-		:	<div className="border border-dashed border-yellow-500">{children}</div>
+		:	<div className={cn('border border-dashed border-yellow-500', className)}>
+				{children}
+			</div>
 }

--- a/src/components/flash-card-review-session.tsx
+++ b/src/components/flash-card-review-session.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import toast from 'react-hot-toast'
 import { Play, ChevronLeft, ChevronRight } from 'lucide-react'
-import { Card, CardContent, CardFooter } from '@/components/ui/card'
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import SuccessCheckmark from '@/components/SuccessCheckmark'
 import { CardFull, ReviewScheduled, uuid } from '@/types/main'
@@ -12,6 +12,7 @@ import { postReview } from '@/lib/use-reviewables'
 import { PostgrestError } from '@supabase/supabase-js'
 import PhraseExtraInfo from './phrase-extra-info'
 import Flagged from './flagged'
+import PermalinkButton from './permalink-button'
 
 interface ComponentProps {
 	cards: Array<CardFull>
@@ -92,10 +93,18 @@ export function FlashCardReviewSession({ lang, cards }: ComponentProps) {
 								i === currentCardIndex ? 'flex' : 'hidden'
 							)}
 						>
+							<CardHeader className="flex flex-row justify-end gap-2">
+								<PermalinkButton
+									variant="ghost"
+									size="icon-sm"
+									text=""
+									url={`${window.location.origin}/learn/${phrase.lang}/${phrase.id}`}
+								/>
+								<PhraseExtraInfo lang={phrase.lang} pid={phrase.id} />
+							</CardHeader>
 							<CardContent
 								className={`flex grow flex-col items-center justify-center px-[10%] pt-0`}
 							>
-								<PhraseExtraInfo lang={phrase.lang} pid={phrase.id} />
 								<div className="mb-4 flex items-center justify-center">
 									<div className="mr-2 text-2xl font-bold">{phrase.text}</div>
 									<Flagged name="text_to_speech">

--- a/src/components/flash-card-review-session.tsx
+++ b/src/components/flash-card-review-session.tsx
@@ -13,6 +13,7 @@ import { PostgrestError } from '@supabase/supabase-js'
 import PhraseExtraInfo from './phrase-extra-info'
 import Flagged from './flagged'
 import PermalinkButton from './permalink-button'
+import SharePhraseButton from './share-phrase-button'
 
 interface ComponentProps {
 	cards: Array<CardFull>
@@ -99,6 +100,13 @@ export function FlashCardReviewSession({ lang, cards }: ComponentProps) {
 									size="icon-sm"
 									text=""
 									url={`${window.location.origin}/learn/${phrase.lang}/${phrase.id}`}
+								/>
+								<SharePhraseButton
+									lang={phrase.lang}
+									pid={phrase.id}
+									variant="ghost"
+									size="icon-sm"
+									text=""
 								/>
 								<PhraseExtraInfo lang={phrase.lang} pid={phrase.id} />
 							</CardHeader>

--- a/src/components/flash-card-review-session.tsx
+++ b/src/components/flash-card-review-session.tsx
@@ -94,20 +94,12 @@ export function FlashCardReviewSession({ lang, cards }: ComponentProps) {
 								i === currentCardIndex ? 'flex' : 'hidden'
 							)}
 						>
-							<CardHeader className="flex flex-row justify-end gap-2">
+							<CardHeader className="flex flex-row items-center justify-end gap-2">
 								<PermalinkButton
-									variant="ghost"
-									size="icon-sm"
-									text=""
-									url={`${window.location.origin}/learn/${phrase.lang}/${phrase.id}`}
+									to={'/learn/$lang/$id'}
+									params={{ lang: phrase.lang, id: phrase.id }}
 								/>
-								<SharePhraseButton
-									lang={phrase.lang}
-									pid={phrase.id}
-									variant="ghost"
-									size="icon-sm"
-									text=""
-								/>
+								<SharePhraseButton lang={phrase.lang} pid={phrase.id} />
 								<PhraseExtraInfo lang={phrase.lang} pid={phrase.id} />
 							</CardHeader>
 							<CardContent

--- a/src/components/language-phrases-accordion.tsx
+++ b/src/components/language-phrases-accordion.tsx
@@ -87,18 +87,15 @@ function PhraseAccordionItem({
 							className="text-xs"
 						/>
 						<PermalinkButton
-							url={`/learn/${phrase.lang}/${phrase.id}`}
-							text="Permalink"
+							to="/learn/$lang/$id"
+							params={{ lang: phrase.lang, id: phrase.id }}
 							variant="link"
-							size="badge"
 							className="text-xs"
 						/>
 						<SharePhraseButton
 							pid={phrase.id}
 							lang={phrase.lang}
-							text="Share"
 							variant="link"
-							size="badge"
 							className="text-xs"
 						/>
 						<PhraseExtraInfo

--- a/src/components/language-phrases-accordion.tsx
+++ b/src/components/language-phrases-accordion.tsx
@@ -10,6 +10,7 @@ import { AddTranslationsDialog } from './add-translations-dialog'
 import { useLanguage } from '@/lib/use-language'
 import { useDeck } from '@/lib/use-deck'
 import PhraseExtraInfo from './phrase-extra-info'
+import PermalinkButton from './permalink-button'
 
 interface PhrasesWithOptionalOrder {
 	lang: string
@@ -77,17 +78,26 @@ function PhraseAccordionItem({
 							</li>
 						))}
 					</ul>
-					<AddTranslationsDialog
-						phrase={phrase}
-						size="badge"
-						variant="link"
-						className="text-xs"
-					/>
-					<PhraseExtraInfo
-						lang={phrase.lang}
-						pid={phrase.id}
-						className="ms-auto"
-					/>
+					<div className="my-4 flex flex-row gap-2">
+						<AddTranslationsDialog
+							phrase={phrase}
+							size="badge"
+							variant="link"
+							className="text-xs"
+						/>
+						<PermalinkButton
+							url={`/learn/${phrase.lang}/${phrase.id}`}
+							text="Permalink"
+							variant="link"
+							size="badge"
+							className="text-xs"
+						/>
+						<PhraseExtraInfo
+							lang={phrase.lang}
+							pid={phrase.id}
+							className="ms-auto"
+						/>
+					</div>
 				</div>
 			</AccordionContent>
 		</AccordionItem>

--- a/src/components/language-phrases-accordion.tsx
+++ b/src/components/language-phrases-accordion.tsx
@@ -11,6 +11,7 @@ import { useLanguage } from '@/lib/use-language'
 import { useDeck } from '@/lib/use-deck'
 import PhraseExtraInfo from './phrase-extra-info'
 import PermalinkButton from './permalink-button'
+import SharePhraseButton from './share-phrase-button'
 
 interface PhrasesWithOptionalOrder {
 	lang: string
@@ -88,6 +89,14 @@ function PhraseAccordionItem({
 						<PermalinkButton
 							url={`/learn/${phrase.lang}/${phrase.id}`}
 							text="Permalink"
+							variant="link"
+							size="badge"
+							className="text-xs"
+						/>
+						<SharePhraseButton
+							pid={phrase.id}
+							lang={phrase.lang}
+							text="Share"
 							variant="link"
 							size="badge"
 							className="text-xs"

--- a/src/components/permalink-button.tsx
+++ b/src/components/permalink-button.tsx
@@ -1,39 +1,27 @@
-import { Copy } from 'lucide-react'
-import { Button } from './ui/button'
-import toast from 'react-hot-toast'
-import { ButtonProps } from './ui/button-variants'
+import { LinkIcon } from 'lucide-react'
+import { ButtonProps, buttonVariants } from './ui/button-variants'
 import { cn } from '@/lib/utils'
+import { Link, LinkProps } from '@tanstack/react-router'
 
 export default function PermalinkButton({
-	url = '',
-	text = 'Copy link',
-	variant = 'outline',
+	to,
+	params,
+	text = 'Permalink',
+	variant = 'ghost',
+	size = 'badge',
 	className = '',
 	...props
-}: {
-	url?: string
-	text?: string
-} & ButtonProps) {
-	const copyLink = () => {
-		url = url || window.location.href
-		navigator.clipboard
-			.writeText(url)
-			.then(() => {
-				toast.success('Link copied to clipboard')
-			})
-			.catch(() => {
-				toast.error('Failed to copy link')
-			})
-	}
-	return (
-		<Button
-			onClick={copyLink}
-			variant={variant}
-			{...props}
-			className={cn('flex items-center gap-2', className)}
-		>
-			<Copy className="h-4 w-4" />
-			{text}
-		</Button>
-	)
+}: { text: string } & LinkProps & ButtonProps) {
+	return !to ? null : (
+			<Link
+				to={to}
+				params={params}
+				className={cn(buttonVariants({ variant, size }), className)}
+				preload="intent"
+				{...props}
+			>
+				<LinkIcon className="h-4 w-4" />
+				<span className="hidden @xl:block">{text}</span>
+			</Link>
+		)
 }

--- a/src/components/permalink-button.tsx
+++ b/src/components/permalink-button.tsx
@@ -1,0 +1,39 @@
+import { Copy } from 'lucide-react'
+import { Button } from './ui/button'
+import toast from 'react-hot-toast'
+import { ButtonProps } from './ui/button-variants'
+import { cn } from '@/lib/utils'
+
+export default function PermalinkButton({
+	url = '',
+	text = 'Copy link',
+	variant = 'outline',
+	className = '',
+	...props
+}: {
+	url?: string
+	text?: string
+} & ButtonProps) {
+	const copyLink = () => {
+		url = url || window.location.href
+		navigator.clipboard
+			.writeText(url)
+			.then(() => {
+				toast.success('Link copied to clipboard')
+			})
+			.catch(() => {
+				toast.error('Failed to copy link')
+			})
+	}
+	return (
+		<Button
+			onClick={copyLink}
+			variant={variant}
+			{...props}
+			className={cn('flex items-center gap-2', className)}
+		>
+			<Copy className="h-4 w-4" />
+			{text}
+		</Button>
+	)
+}

--- a/src/components/share-phrase-button.tsx
+++ b/src/components/share-phrase-button.tsx
@@ -3,7 +3,6 @@ import type { uuid } from '@/types/main'
 import { Share2 } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { Button } from './ui/button'
-import { cn } from '@/lib/utils'
 import { useLanguagePhrase } from '@/lib/use-language'
 import languages from '@/lib/languages'
 
@@ -11,7 +10,8 @@ export default function SharePhraseButton({
 	lang,
 	pid,
 	text = 'Share phrase',
-	variant = 'outline',
+	variant = 'ghost',
+	size = 'badge',
 	className = '',
 	...props
 }: {
@@ -19,6 +19,7 @@ export default function SharePhraseButton({
 	pid: uuid
 	text?: string
 	variant?: string
+	size?: string
 	className?: string
 } & ButtonProps) {
 	const { data: phrase, isPending } = useLanguagePhrase(pid, lang)
@@ -39,11 +40,12 @@ export default function SharePhraseButton({
 		<Button
 			onClick={sharePhrase}
 			variant={variant}
-			className={cn('flex items-center gap-2', className)}
+			size={size}
+			className={className}
 			{...props}
 		>
 			<Share2 className="h-4 w-4" />
-			{text}
+			<span className="hidden @xl:block">{text}</span>
 		</Button>
 	)
 }

--- a/src/components/share-phrase-button.tsx
+++ b/src/components/share-phrase-button.tsx
@@ -1,0 +1,49 @@
+import type { ButtonProps } from './ui/button-variants'
+import type { uuid } from '@/types/main'
+import { Share2 } from 'lucide-react'
+import toast from 'react-hot-toast'
+import { Button } from './ui/button'
+import { cn } from '@/lib/utils'
+import { useLanguagePhrase } from '@/lib/use-language'
+import languages from '@/lib/languages'
+
+export default function SharePhraseButton({
+	lang,
+	pid,
+	text = 'Share phrase',
+	variant = 'outline',
+	className = '',
+	...props
+}: {
+	lang: string
+	pid: uuid
+	text?: string
+	variant?: string
+	className?: string
+} & ButtonProps) {
+	const { data: phrase, isPending } = useLanguagePhrase(pid, lang)
+	if (isPending || !phrase || !navigator.share) return null
+
+	const shareContent = {
+		title: `Sunlo: ${phrase.text}`,
+		text: `Check out this phrase in ${languages[lang]}: ${phrase.text}`,
+		url: `${window.location.origin}/learn/${lang}/${phrase.id}`,
+	}
+
+	const sharePhrase = () => {
+		navigator.share(shareContent).catch(() => {
+			toast.error('Failed to share')
+		})
+	}
+	return (
+		<Button
+			onClick={sharePhrase}
+			variant={variant}
+			className={cn('flex items-center gap-2', className)}
+			{...props}
+		>
+			<Share2 className="h-4 w-4" />
+			{text}
+		</Button>
+	)
+}

--- a/src/components/ui/button-variants.tsx
+++ b/src/components/ui/button-variants.tsx
@@ -23,7 +23,7 @@ const buttonVariants = cva(
 				lg: 'rounded-md px-8 py-4 text-xl font-medium rounded-lg gap-3',
 				icon: 'size-10 rounded-full shrink-0',
 				'icon-sm': 'size-6 rounded-full shrink-0',
-				badge: 'h-6 rounded-full font-sm px-2 gap-1',
+				badge: 'h-6 rounded-full font-sm px-2 gap-1 my-0',
 			},
 		},
 		defaultVariants: {

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -14,4 +14,5 @@ export const flags: FlagMap = {
 	friends_activity: { enabled: false },
 	learning_goals: { enabled: false },
 	text_to_speech: { enabled: false },
+	cards_schedule_metadata: { enabled: false },
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -44,6 +44,7 @@ import { Route as UserLearnLangReviewImport } from './routes/_user/learn.$lang.r
 import { Route as UserLearnLangLibraryImport } from './routes/_user/learn.$lang.library'
 import { Route as UserLearnLangDeckSettingsImport } from './routes/_user/learn.$lang.deck-settings'
 import { Route as UserLearnLangAddPhraseImport } from './routes/_user/learn.$lang.add-phrase'
+import { Route as UserLearnLangIdImport } from './routes/_user/learn.$lang.$id'
 import { Route as UserFriendsSearchUidImport } from './routes/_user/friends.search.$uid'
 
 // Create Virtual Routes
@@ -268,6 +269,12 @@ const UserLearnLangAddPhraseRoute = UserLearnLangAddPhraseImport.update({
   getParentRoute: () => UserLearnLangRoute,
 } as any)
 
+const UserLearnLangIdRoute = UserLearnLangIdImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => UserLearnLangRoute,
+} as any)
+
 const UserFriendsSearchUidRoute = UserFriendsSearchUidImport.update({
   id: '/$uid',
   path: '/$uid',
@@ -488,6 +495,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UserFriendsSearchUidImport
       parentRoute: typeof UserFriendsSearchImport
     }
+    '/_user/learn/$lang/$id': {
+      id: '/_user/learn/$lang/$id'
+      path: '/$id'
+      fullPath: '/learn/$lang/$id'
+      preLoaderRoute: typeof UserLearnLangIdImport
+      parentRoute: typeof UserLearnLangImport
+    }
     '/_user/learn/$lang/add-phrase': {
       id: '/_user/learn/$lang/add-phrase'
       path: '/add-phrase'
@@ -583,6 +597,7 @@ const UserFriendsRouteWithChildren = UserFriendsRoute._addFileChildren(
 )
 
 interface UserLearnLangRouteChildren {
+  UserLearnLangIdRoute: typeof UserLearnLangIdRoute
   UserLearnLangAddPhraseRoute: typeof UserLearnLangAddPhraseRoute
   UserLearnLangDeckSettingsRoute: typeof UserLearnLangDeckSettingsRoute
   UserLearnLangLibraryRoute: typeof UserLearnLangLibraryRoute
@@ -592,6 +607,7 @@ interface UserLearnLangRouteChildren {
 }
 
 const UserLearnLangRouteChildren: UserLearnLangRouteChildren = {
+  UserLearnLangIdRoute: UserLearnLangIdRoute,
   UserLearnLangAddPhraseRoute: UserLearnLangAddPhraseRoute,
   UserLearnLangDeckSettingsRoute: UserLearnLangDeckSettingsRoute,
   UserLearnLangLibraryRoute: UserLearnLangLibraryRoute,
@@ -688,6 +704,7 @@ export interface FileRoutesByFullPath {
   '/learn/': typeof UserLearnIndexRoute
   '/profile/': typeof UserProfileIndexRoute
   '/friends/search/$uid': typeof UserFriendsSearchUidRoute
+  '/learn/$lang/$id': typeof UserLearnLangIdRoute
   '/learn/$lang/add-phrase': typeof UserLearnLangAddPhraseRoute
   '/learn/$lang/deck-settings': typeof UserLearnLangDeckSettingsRoute
   '/learn/$lang/library': typeof UserLearnLangLibraryRoute
@@ -722,6 +739,7 @@ export interface FileRoutesByTo {
   '/learn': typeof UserLearnIndexRoute
   '/profile': typeof UserProfileIndexRoute
   '/friends/search/$uid': typeof UserFriendsSearchUidRoute
+  '/learn/$lang/$id': typeof UserLearnLangIdRoute
   '/learn/$lang/add-phrase': typeof UserLearnLangAddPhraseRoute
   '/learn/$lang/deck-settings': typeof UserLearnLangDeckSettingsRoute
   '/learn/$lang/library': typeof UserLearnLangLibraryRoute
@@ -762,6 +780,7 @@ export interface FileRoutesById {
   '/_user/learn/': typeof UserLearnIndexRoute
   '/_user/profile/': typeof UserProfileIndexRoute
   '/_user/friends/search/$uid': typeof UserFriendsSearchUidRoute
+  '/_user/learn/$lang/$id': typeof UserLearnLangIdRoute
   '/_user/learn/$lang/add-phrase': typeof UserLearnLangAddPhraseRoute
   '/_user/learn/$lang/deck-settings': typeof UserLearnLangDeckSettingsRoute
   '/_user/learn/$lang/library': typeof UserLearnLangLibraryRoute
@@ -802,6 +821,7 @@ export interface FileRouteTypes {
     | '/learn/'
     | '/profile/'
     | '/friends/search/$uid'
+    | '/learn/$lang/$id'
     | '/learn/$lang/add-phrase'
     | '/learn/$lang/deck-settings'
     | '/learn/$lang/library'
@@ -835,6 +855,7 @@ export interface FileRouteTypes {
     | '/learn'
     | '/profile'
     | '/friends/search/$uid'
+    | '/learn/$lang/$id'
     | '/learn/$lang/add-phrase'
     | '/learn/$lang/deck-settings'
     | '/learn/$lang/library'
@@ -873,6 +894,7 @@ export interface FileRouteTypes {
     | '/_user/learn/'
     | '/_user/profile/'
     | '/_user/friends/search/$uid'
+    | '/_user/learn/$lang/$id'
     | '/_user/learn/$lang/add-phrase'
     | '/_user/learn/$lang/deck-settings'
     | '/_user/learn/$lang/library'
@@ -1033,6 +1055,7 @@ export const routeTree = rootRoute
       "filePath": "_user/learn.$lang.tsx",
       "parent": "/_user/learn",
       "children": [
+        "/_user/learn/$lang/$id",
         "/_user/learn/$lang/add-phrase",
         "/_user/learn/$lang/deck-settings",
         "/_user/learn/$lang/library",
@@ -1076,6 +1099,10 @@ export const routeTree = rootRoute
     "/_user/friends/search/$uid": {
       "filePath": "_user/friends.search.$uid.tsx",
       "parent": "/_user/friends/search"
+    },
+    "/_user/learn/$lang/$id": {
+      "filePath": "_user/learn.$lang.$id.tsx",
+      "parent": "/_user/learn/$lang"
     },
     "/_user/learn/$lang/add-phrase": {
       "filePath": "_user/learn.$lang.add-phrase.tsx",

--- a/src/routes/_user/learn.$lang.$id.tsx
+++ b/src/routes/_user/learn.$lang.$id.tsx
@@ -1,5 +1,6 @@
 import { AddTranslationsDialog } from '@/components/add-translations-dialog'
 import { CardStatusDropdown } from '@/components/card-status-dropdown'
+import PermalinkButton from '@/components/permalink-button'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import Callout from '@/components/ui/callout'
@@ -46,17 +47,7 @@ function RouteComponent() {
 	if (phrase === null) return <PhraseNotFound />
 
 	const card = deck.cardsMap[id] ?? null
-	const copyLink = () => {
-		const url = window.location.href
-		navigator.clipboard
-			.writeText(url)
-			.then(() => {
-				toast.success('Link copied to clipboard')
-			})
-			.catch(() => {
-				toast.error('Failed to copy link')
-			})
-	}
+
 	const sharePhrase = () => {
 		if (navigator.share) {
 			navigator
@@ -131,14 +122,7 @@ function RouteComponent() {
 					<Separator />
 
 					<div className="flex flex-wrap gap-2">
-						<Button
-							onClick={copyLink}
-							variant="outline"
-							className="flex items-center gap-2"
-						>
-							<Copy className="h-4 w-4" />
-							Copy link
-						</Button>
+						<PermalinkButton />
 						<Button
 							onClick={sharePhrase}
 							variant="outline"

--- a/src/routes/_user/learn.$lang.$id.tsx
+++ b/src/routes/_user/learn.$lang.$id.tsx
@@ -1,7 +1,7 @@
 import { AddTranslationsDialog } from '@/components/add-translations-dialog'
 import { CardStatusDropdown } from '@/components/card-status-dropdown'
 import Flagged from '@/components/flagged'
-import PermalinkButton from '@/components/permalink-button'
+import CopyLinkButton from '@/components/copy-link-button'
 import SharePhraseButton from '@/components/share-phrase-button'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -110,8 +110,13 @@ function RouteComponent() {
 					<Separator />
 
 					<div className="flex flex-wrap gap-2">
-						<PermalinkButton />
-						<SharePhraseButton pid={phrase.id} lang={phrase.lang} />
+						<CopyLinkButton variant="outline" size="default" />
+						<SharePhraseButton
+							pid={phrase.id}
+							lang={phrase.lang}
+							variant="outline"
+							size="default"
+						/>
 						<div className="flex-grow"></div>
 						<Link to={`/learn/${lang}/library`}>
 							<Button variant="ghost">Back to library</Button>

--- a/src/routes/_user/learn.$lang.$id.tsx
+++ b/src/routes/_user/learn.$lang.$id.tsx
@@ -1,0 +1,159 @@
+import { AddTranslationsDialog } from '@/components/add-translations-dialog'
+import { CardStatusDropdown } from '@/components/card-status-dropdown'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import Callout from '@/components/ui/callout'
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from '@/components/ui/card'
+import { Separator } from '@/components/ui/separator'
+import languages from '@/lib/languages'
+import { deckQueryOptions } from '@/lib/use-deck'
+import { languageQueryOptions } from '@/lib/use-language'
+import { useQuery } from '@tanstack/react-query'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { Calendar, Copy, OctagonMinus, Plus, Share2 } from 'lucide-react'
+import toast from 'react-hot-toast'
+
+export const Route = createFileRoute('/_user/learn/$lang/$id')({
+	component: RouteComponent,
+})
+
+function PhraseNotFound() {
+	return (
+		<Callout variant="problem">
+			<Badge variant="destructive" className="p-2">
+				<OctagonMinus />
+			</Badge>
+			<p>We couldn't find that phrase. Please check your link and try again.</p>
+		</Callout>
+	)
+}
+
+function RouteComponent() {
+	const { lang, id } = Route.useParams()
+	const {
+		auth: { userId },
+	} = Route.useRouteContext()
+	const { data: language } = useQuery(languageQueryOptions(lang))
+	const { data: deck } = useQuery(deckQueryOptions(lang, userId))
+	const phrase = language.phrasesMap[id] ?? null
+
+	if (phrase === null) return <PhraseNotFound />
+
+	const card = deck.cardsMap[id] ?? null
+	const copyLink = () => {
+		const url = window.location.href
+		navigator.clipboard
+			.writeText(url)
+			.then(() => {
+				toast.success('Link copied to clipboard')
+			})
+			.catch(() => {
+				toast.error('Failed to copy link')
+			})
+	}
+	const sharePhrase = () => {
+		if (navigator.share) {
+			navigator
+				.share({
+					title: `Sunlo: ${phrase.text}`,
+					text: `Check out this phrase in ${languages[phrase.lang]}: ${phrase.text}`,
+					url: window.location.href,
+				})
+				.catch(() => {
+					toast.error('Failed to share')
+				})
+		} else {
+			copyLink()
+		}
+	}
+
+	return (
+		<Card>
+			<CardHeader>
+				<div className="flex items-center justify-between">
+					<div className="flex items-center gap-2">
+						<CardTitle className="text-2xl">{phrase.text}</CardTitle>
+						<Badge variant="outline" className="ml-2">
+							{languages[phrase.lang]}
+						</Badge>
+					</div>
+					<CardStatusDropdown
+						deckId={deck.meta.id}
+						card={card}
+						pid={phrase.id}
+						lang={lang}
+					/>
+				</div>
+				<CardDescription className="mt-2 flex items-center gap-2">
+					{!card ?
+						<p>This card is not in your deck</p>
+					:	<>
+							<span>Difficulty score {card?.difficultyScore ?? '7'}/10</span>
+							<span className="mx-2">•</span>
+							<Calendar className="h-4 w-4" />
+							<span>
+								Next review scheduled for {card?.nextReview?.day ?? 'Tuesday'}{' '}
+								(in {card?.nextReview?.daysFromNow ?? '4'} days)
+							</span>
+						</>
+					}
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div className="space-y-6">
+					<div>
+						<h3 className="mb-3 text-lg font-medium">Translations</h3>
+						<div className="space-y-3">
+							{phrase.translations.map((translation) => (
+								<div key={translation.id} className="bg-muted rounded-lg p-3">
+									<div className="flex items-center justify-between">
+										<p className="text-md">{translation.text}</p>
+										<Badge variant="outline">
+											{languages[translation.lang]}
+										</Badge>
+									</div>
+								</div>
+							))}
+							<AddTranslationsDialog
+								phrase={phrase}
+								variant="outline"
+								className="mt-2 w-full"
+							/>
+						</div>
+					</div>
+
+					<Separator />
+
+					<div className="flex flex-wrap gap-2">
+						<Button
+							onClick={copyLink}
+							variant="outline"
+							className="flex items-center gap-2"
+						>
+							<Copy className="h-4 w-4" />
+							Copy link
+						</Button>
+						<Button
+							onClick={sharePhrase}
+							variant="outline"
+							className="flex items-center gap-2"
+						>
+							<Share2 className="h-4 w-4" />
+							Share phrase
+						</Button>
+						<div className="flex-grow"></div>
+						<Link to={`/learn/${lang}/library`}>
+							<Button variant="ghost">Back to library</Button>
+						</Link>
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	)
+}

--- a/src/routes/_user/learn.$lang.$id.tsx
+++ b/src/routes/_user/learn.$lang.$id.tsx
@@ -1,5 +1,6 @@
 import { AddTranslationsDialog } from '@/components/add-translations-dialog'
 import { CardStatusDropdown } from '@/components/card-status-dropdown'
+import Flagged from '@/components/flagged'
 import PermalinkButton from '@/components/permalink-button'
 import SharePhraseButton from '@/components/share-phrase-button'
 import { Badge } from '@/components/ui/badge'
@@ -68,7 +69,10 @@ function RouteComponent() {
 				<CardDescription className="mt-2 flex items-center gap-2">
 					{!card ?
 						<p>This card is not in your deck</p>
-					:	<>
+					:	<Flagged
+							className="flex flex-row items-center gap-1"
+							name="cards_schedule_metadata"
+						>
 							<span>Difficulty score {card?.difficultyScore ?? '7'}/10</span>
 							<span className="mx-2">•</span>
 							<Calendar className="h-4 w-4" />
@@ -76,7 +80,7 @@ function RouteComponent() {
 								Next review scheduled for {card?.nextReview?.day ?? 'Tuesday'}{' '}
 								(in {card?.nextReview?.daysFromNow ?? '4'} days)
 							</span>
-						</>
+						</Flagged>
 					}
 				</CardDescription>
 			</CardHeader>

--- a/src/routes/_user/learn.$lang.$id.tsx
+++ b/src/routes/_user/learn.$lang.$id.tsx
@@ -1,6 +1,7 @@
 import { AddTranslationsDialog } from '@/components/add-translations-dialog'
 import { CardStatusDropdown } from '@/components/card-status-dropdown'
 import PermalinkButton from '@/components/permalink-button'
+import SharePhraseButton from '@/components/share-phrase-button'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import Callout from '@/components/ui/callout'
@@ -17,8 +18,7 @@ import { deckQueryOptions } from '@/lib/use-deck'
 import { languageQueryOptions } from '@/lib/use-language'
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { Calendar, Copy, OctagonMinus, Plus, Share2 } from 'lucide-react'
-import toast from 'react-hot-toast'
+import { Calendar, OctagonMinus } from 'lucide-react'
 
 export const Route = createFileRoute('/_user/learn/$lang/$id')({
 	component: RouteComponent,
@@ -47,22 +47,6 @@ function RouteComponent() {
 	if (phrase === null) return <PhraseNotFound />
 
 	const card = deck.cardsMap[id] ?? null
-
-	const sharePhrase = () => {
-		if (navigator.share) {
-			navigator
-				.share({
-					title: `Sunlo: ${phrase.text}`,
-					text: `Check out this phrase in ${languages[phrase.lang]}: ${phrase.text}`,
-					url: window.location.href,
-				})
-				.catch(() => {
-					toast.error('Failed to share')
-				})
-		} else {
-			copyLink()
-		}
-	}
 
 	return (
 		<Card>
@@ -123,14 +107,7 @@ function RouteComponent() {
 
 					<div className="flex flex-wrap gap-2">
 						<PermalinkButton />
-						<Button
-							onClick={sharePhrase}
-							variant="outline"
-							className="flex items-center gap-2"
-						>
-							<Share2 className="h-4 w-4" />
-							Share phrase
-						</Button>
+						<SharePhraseButton pid={phrase.id} lang={phrase.lang} />
 						<div className="flex-grow"></div>
 						<Link to={`/learn/${lang}/library`}>
 							<Button variant="ghost">Back to library</Button>


### PR DESCRIPTION
This PR should:
* Add a new route for a specific phrase
* Add permalinks to other places where phrases are displayed
* Stretch: add metadata like card difficulty to the `user_card_plus` view